### PR TITLE
Improve the run button and behaviour

### DIFF
--- a/src/lib/components/Playground/Playground.svelte
+++ b/src/lib/components/Playground/Playground.svelte
@@ -360,7 +360,7 @@
 			>
 				{#if loading}
 					<div class="flex flex-none items-center gap-[3px]">
-						<span class="mr-2">Abort</span>
+						<span class="mr-2">Cancel</span>
 						<div
 							class="h-1 w-1 flex-none animate-bounce rounded-full bg-gray-500 dark:bg-gray-100"
 							style="animation-delay: 0.25s;"


### PR DESCRIPTION
## Improve the run button and behaviour

1. Changed the shortcut from `cmd+enter` to just `enter` (which is the case on all chatbots including chatgpt, claude)
2. Previously, it was only possible to cancel/abort streaming message. This PR adds cancel/abort to non-streaming messages as well.
3. While message is being generated: 1. the user cannot edit the existing messages and the blue `run` btn turns into red `cancel` btn;  2. for non-streaming messages, the background does pulsating animation for giving a better feedback to the user.

