### PR TITLE
Improve messages UX

### DIFF
--- a/src/lib/components/Playground/Playground.svelte
+++ b/src/lib/components/Playground/Playground.svelte
@@ -108,6 +108,7 @@
 	}
 
 	async function submit() {
+		// last message has to be from user
 		if(currentConversation.messages?.at(-1)?.role !== "user"){
 			addMessage();
 			return;


### PR DESCRIPTION
# Improve messages UX

When sending messages to an assistant, the messages has to alternate in user/assistant pairs. In the inference-playground, we allow editing or deleting messages, which can break this "alternate in user/assistant pairs" format. This PR fixes the issue