### PR TITLE
Fix streaming extra new lines

### DIFF
--- a/src/lib/components/InferencePlayground/InferencePlayground.svelte
+++ b/src/lib/components/InferencePlayground/InferencePlayground.svelte
@@ -132,8 +132,8 @@
 		const hf = createHfInference(hfToken);
 
 		if (conversation.streaming) {
+			let addStreamingMessage = true;
 			const streamingMessage = { role: "assistant", content: "" };
-			conversation.messages = [...conversation.messages, streamingMessage];
 			const abortController = new AbortController();
 			abortControllers.push(abortController);
 
@@ -143,6 +143,10 @@
 				content => {
 					if (streamingMessage) {
 						streamingMessage.content = content;
+						if (addStreamingMessage) {
+							conversation.messages = [...conversation.messages, streamingMessage];
+							addStreamingMessage = false;
+						}
 						session = session;
 						generationStats[conversationIdx].generatedTokensCount += 1;
 					}


### PR DESCRIPTION
Without this change/PR, the messages input body was:
```ts
"messages": [
    { "role": "user", "content": "hey" },
    { "role": "assistant", "content": "" }
],
```
which was causing erroneous output: `\n\nHello how can I help you?` (see the extra newlines `\n\n`)

It should be just:
```ts
"messages": [
    { "role": "user", "content": "hey" },
],
```
which was causing correct output: `Hello how can I help you?`